### PR TITLE
Add options parameter to mock methods

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,0 +1,11 @@
+# 0.0.3
+
+* enhancements
+  * Add optional `options` parameter to mocking methods. This allows 
+    you to specify `:passthrough` to meck.
+
+* bug fix
+
+* deprecations
+
+* backwards incompatible changes

--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -34,9 +34,9 @@ defmodule Mock do
          assert called HTTPotion.get("http://example.com")
       end
   """
-  defmacro with_mock(mock_module, mocks, test) do
+  defmacro with_mock(mock_module, options // [], mocks, test) do
     quote do
-      :meck.new(unquote(mock_module))
+      :meck.new(unquote(mock_module), unquote(options))
       unquote(__MODULE__)._install_mock(unquote(mock_module), unquote(mocks))
       try do
         # Do all the tests inside so we can kill the mock
@@ -61,11 +61,11 @@ defmodule Mock do
         assert called HTTPotion.get("http://example.com")
       end
   """
-  defmacro test_with_mock(test_name, mock_module, mocks, test_block) do
+  defmacro test_with_mock(test_name, mock_module, options // [], mocks, test_block) do
     quote do
       test unquote(test_name) do
         unquote(__MODULE__).with_mock(
-            unquote(mock_module), unquote(mocks), unquote(test_block))
+            unquote(mock_module), unquote(options), unquote(mocks), unquote(test_block))
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Mock.Mixfile do
       name: "Mock",
       source_url: "https://github.com/jjh42/mock",
       homepage_url: "http://jjh42.github.io/mock",
-      version: "0.0.2",
+      version: "0.0.3",
       env: [
           dev: [deps: deps ++ dev_deps],
           test: [deps: deps] ,


### PR DESCRIPTION
I needed to be able to specify `:passthrough` on modules I was mocking, so I added an optional parameter.

Dave
