### PR TITLE
Update dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Mock.Mixfile do
   # Returns the list of dependencies in the format:
   # { :foobar, "0.1", git: "https://github.com/elixir-lang/foobar.git" }
   defp deps do
-    [ {:meck,"0.7.2", [github: "eproxus/meck"]}]
+    [ {:meck,"0.7.2", [github: "eproxus/meck", tag: "0.7.2"]}]
   end
 
   # Dependencies only needed during development.


### PR DESCRIPTION
The dependency meck has some newer tags, so a tag atom seems to be required for it to do the right thing. This is using elixir 0.10.0
