### PR TITLE
Feat/with context

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ defmodule MyTest do
 end
 ````
 
+The `test_with_mock` macro can also be passed a context argument
+allowing the sharing of information between callbacks and the test
+
+```` elixir
+defmodule MyTest do
+  use ExUnit.Case, async: false
+
+  import Mock
+
+  setup do
+    doc = "<html></html>"
+    {:ok, doc: doc}
+  end
+
+  test_with_mock "test_with_mock with context", %{doc: doc}, HTTPotion, [],
+    [get: fn(_url) -> doc end] do
+
+    HTTPotion.get("http://example.com")
+    assert called HTTPotion.get("http://example.com")
+  end
+end
+````
+
 The `with_mock` creates a mock module. The keyword list provides a set
 of mock implementation for functions we want to provide in the mock (in
 this case just `get`). Inside `with_mock` we exercise the test code

--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -76,6 +76,35 @@ defmodule Mock do
   end
 
   @doc """
+  Shortcut to avoid multiple blocks when a test requires a single
+  mock. Accepts a context argument enabling information to be shared
+  between callbacks and the test.
+
+  For full description see `with_mock`.
+
+  ## Example
+      setup do
+        doc = "<html></html>"
+        {:ok, doc: doc}
+      end
+
+      test_with_mock "test_with_mock with context", %{doc: doc}, HTTPotion, [],
+        [get: fn(_url) -> doc end] do
+
+        HTTPotion.get("http://example.com")
+        assert called HTTPotion.get("http://example.com")
+      end
+  """
+  defmacro test_with_mock(test_name, context, mock_module, opts, mocks, test_block) do
+    quote do
+      test unquote(test_name), unquote(context) do
+        unquote(__MODULE__).with_mock(
+            unquote(mock_module), unquote(opts), unquote(mocks), unquote(test_block))
+      end
+    end
+  end
+
+  @doc """
     Use inside a `with_mock` block to determine whether
     a mocked function was called as expected.
 

--- a/test/mock_test.exs
+++ b/test/mock_test.exs
@@ -5,6 +5,11 @@ defmodule MockTest do
   use ExUnit.Case, async: false
   import Mock
 
+  setup_all do
+    foo = "bar"
+    {:ok, foo: foo}
+  end
+
   test "simple mock" do
     with_mock String,
         [reverse: fn(x) -> 2*x end] do
@@ -28,6 +33,14 @@ defmodule MockTest do
     String,
     [reverse: fn(_x) -> :ok end] do
     assert String.reverse 3
+    assert called String.reverse(3)
+    refute called String.reverse(4)
+  end
+
+  test_with_mock "test_with_mock with context", %{foo: foo}, String, [],
+    [reverse: fn(_x) -> :ok end] do
+    assert String.reverse 3
+    assert foo == "bar"
     assert called String.reverse(3)
     refute called String.reverse(4)
   end


### PR DESCRIPTION
A new `test_with_mock/6` function has been added to the Mock module.
This new function differs from the `test_with_mock/5` function by
excepting a context argument.

This allows `test_with_mock` to be used with the standard ExUnit setup
procedure, enabling information to be shared between callbacks and tests.

Additionally an example of the `with_mock` macro has now been added to the README.
