### PR TITLE
Simplify travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,5 @@
-language: erlang
+language: elixir
+env:
+  - MIX_ENV=test 
 otp_release:
   - 17.3
-before_install:
-  - wget http://s3.hex.pm/builds/elixir/v1.0.0.zip
-  - unzip -d elixir v1.0.0.zip
-before_script:
-  - export PATH=`pwd`/elixir/bin:$PATH
-  - mix local.hex --force
-  - MIX_ENV=test mix do deps.get
-script:
-  - MIX_ENV=test mix test


### PR DESCRIPTION
I did not specify the version of `elixir` in the update just to let it test against the default version in `travis-ci`. If you have a need to specify just put it under `elixir: 1.0.0` just after `language`