### PR TITLE
fix doc

### DIFF
--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -62,7 +62,7 @@ defmodule Mock do
   ## Example
 
       test_with_mock "test_name", HTTPotion,
-        [get: fn(_url) -> "<html></html>"] do
+        [get: fn(_url) -> "<html></html>" end] do
         HTTPotion.get("http://example.com")
         assert called HTTPotion.get("http://example.com")
       end


### PR DESCRIPTION
just missing `end` in doc.
`mix hex.docs` should also be run after merging to fix [docs in hex.pm](http://hexdocs.pm/mock/).