### PR TITLE
Readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ and we can check that the call was made as we expected using `called` and
 providing the example of the call we expected (the second argument `:_` has a
 special meaning of matching anything).
 
-You can also pass the option `:passthrough` to retain the origina module
+You can also pass the option `:passthrough` to retain the original module
 functionality. For example
 ```` elixir
 defmodule MyTest do

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ defmodule MyTest do
   end
 
   test_with_mock "test_with_mock with context", %{doc: doc}, HTTPotion, [],
-    [get: fn(_url) -> doc end] do
+    [get: fn(_url, _headers) -> doc end] do
 
-    HTTPotion.get("http://example.com")
-    assert called HTTPotion.get("http://example.com")
+    HTTPotion.get("http://example.com", [foo: :bar])
+    assert called HTTPotion.get("http://example.com", :_)
   end
 end
 ````

--- a/README.md
+++ b/README.md
@@ -3,14 +3,13 @@
 # Mock
 A mocking libary for the Elixir language.
 
-We use the Erlang  [meck library](https://github.com/eproxus/meck) to provide module
-mocking functionality for Elixir. It uses macros in Elixir to expose
-the functionality in a convenient manner for integrating in Elixir tests.
+We use the Erlang [meck library](https://github.com/eproxus/meck) to provide
+module mocking functionality for Elixir. It uses macros in Elixir to expose the
+functionality in a convenient manner for integrating in Elixir tests.
 
 See the full [reference documentation](http://jjh42.github.io/mock).
 
 ## Installation
-
 First, add mock to your `mix.exs` dependencies:
 
 ```elixir
@@ -93,14 +92,15 @@ and we can check that the call was made as we expected using `called` and
 providing the example of the call we expected (the second argument `:_` has a
 special meaning of matching anything).
 
-You can also pass the option `:passthrough` to retain the origina module functionality. For example
+You can also pass the option `:passthrough` to retain the origina module
+functionality. For example
 ```` elixir
 defmodule MyTest do
   use ExUnit.Case, async: false
   import Mock
 
   test_with_mock "test_name", IO, [:passthrough], [] do
-	IO.puts "hello"
+    IO.puts "hello"
     assert called IO.puts "hello"
   end
 end
@@ -110,22 +110,18 @@ Currently, mocking modules cannot be done asynchronously, so make sure that you
 are not using `async: true` in any module where you are testing.
 
 ## Tips
+The use of mocking can be somewhat controversial. I personally think that it
+works well for certain types of tests. Certainly, you should not overuse it. It
+is best to write as much as possible of your code as pure functions which don't
+require mocking to test. However, when interacting with the real world (or web
+services, users etc.) sometimes side-effects are necessary. In these cases,
+mocking is one useful approach for testing this functionality.
 
-The use of mocking can be somewhat controversial. I personally think that it works
-well for certain types of tests. Certainly, you should not overuse it. It is
-best to write as much as possible of your code as pure functions which don't
-require mocking to test. However, when interacting with the real world (or web services,
-users etc.) sometimes side-effects are necessary. In these cases, mocking is one
-useful approach for testing this functionality.
-
-Also, note that Mock has a global effect so if you are using Mocks in multiple tests set
-`async: false` so that only one test runs at a time.
+Also, note that Mock has a global effect so if you are using Mocks in multiple
+tests set `async: false` so that only one test runs at a time.
 
 ## Help
-
 Open an issue.
 
-
 ## Suggestions
-
 I'd welcome suggestions for improvements or bugfixes. Just open an issue.

--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -31,7 +31,7 @@ defmodule Mock do
 
   ## Example
 
-      with_mock(HTTPPotion, [get: fn("http://example.com") ->
+      with_mock(HTTPotion, [get: fn("http://example.com") ->
            "<html></html>" end] do
          # Tests that make the expected call
          assert called HTTPotion.get("http://example.com")


### PR DESCRIPTION
The readme references a `:_` which is no longer in the actual example (changed in f3f37e61867922aba857d51482b2aa9b8c0c2823).

The referenced `:_` argument confused me and apparently other people as well (see #31), so re-adding it in the example instead of removing it from the description seemed like the right way to go.

I also removed some typo's and whitespace issues I ran into.