### PR TITLE
Remove implicit dependency on ExUnit assertions

### DIFF
--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -65,7 +65,7 @@ defmodule Mock do
         end
 
         unquote(__MODULE__)._install_mock(m, mock_fns)
-        assert :meck.validate(m) == true
+        true = :meck.validate(m)
 
         [ m | ms] |> Enum.uniq
       end)

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Mock.Mixfile do
       name: "Mock",
       version: @version,
       elixir: "~> 1.0",
+      elixirc_paths: elixirc_paths(Mix.env),
       description: description,
       package: package,
       test_coverage: [tool: ExCoveralls],
@@ -58,4 +59,7 @@ defmodule Mock.Mixfile do
       }
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 end

--- a/test/mock_test.exs
+++ b/test/mock_test.exs
@@ -4,6 +4,7 @@ Code.require_file "test_helper.exs", __DIR__
 defmodule MockTest do
   use ExUnit.Case, async: false
   import Mock
+  alias MockTest.Helper
 
   setup_all do
     foo = "bar"
@@ -40,6 +41,10 @@ defmodule MockTest do
       String.reverse(3)
     end
     assert result == 6
+  end
+
+  test "mock in an external module" do
+    assert Helper.foo == :bar
   end
 
   test "called" do

--- a/test/support/helper.ex
+++ b/test/support/helper.ex
@@ -1,0 +1,13 @@
+defmodule Foo do
+  def bar, do: :qux
+end
+
+defmodule MockTest.Helper do
+  import Mock
+
+  def foo do
+    with_mock Foo, [bar: fn -> :bar end] do
+      Foo.bar
+    end
+  end
+end


### PR DESCRIPTION
This allows `with_mock` and friends to be used outside of test
libraries.

I tried importing `assert` in the mock.ex, but macros seem to only use imports from their calling context (I'm still not 100% clear on the details of this). If you have a better idea let me know.

Fixes #50 
