### PR TITLE
Add multiple arity example and fix warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ defmodule MyTest do
 
   test "multiple mocks" do
     with_mocks([
-      {HashDict,
+      {Map,
        [],
        [get: fn(%{}, "http://example.com") -> "<html></html>" end]},
       {String,
@@ -67,7 +67,7 @@ defmodule MyTest do
        [reverse: fn(x) -> 2*x end,
         length: fn(_x) -> :ok end]}
     ]) do
-      assert HashDict.get(%{}, "http://example.com") == "<html></html>"
+      assert Map.get(%{}, "http://example.com") == "<html></html>"
       assert String.reverse(3) == 6
       assert String.length(3) == :ok
     end
@@ -95,6 +95,27 @@ defmodule MyTest do
     end
   end
 end
+````
+
+You can mock functions in the same module with different arity.
+The same way you could mock function with optional args.
+```` elixir
+defmodule MyTest do
+  use ExUnit.Case, async: false
+
+  import Mock
+
+  test "mock fuctions with different arity" do
+    with_mock String,
+      [slice: fn(string, range)      -> string end,
+       slice: fn(string, range, len) -> string end]
+    do
+      assert String.slice("test", 1..3) == "test"
+      assert String.slice("test", 1, 3) == "test"
+    end
+  end
+end
+
 ````
 
 An additional convenience macro `test_with_mock` is supplied which
@@ -170,14 +191,14 @@ defmodule MyTest do
   import Mock
 
   setup_with_mocks([
-    {HashDict, [], [get: fn(%{}, "http://example.com") -> "<html></html>" end]}
+    {Map, [], [get: fn(%{}, "http://example.com") -> "<html></html>" end]}
   ]) do
     foo = "bar"
     {:ok, foo: foo}
   end
 
   test "setup_with_mocks" do
-    assert HashDict.get(%{}, "http://example.com") == "<html></html>"
+    assert Map.get(%{}, "http://example.com") == "<html></html>"
   end
 end
 ````

--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -144,14 +144,14 @@ defmodule Mock do
 
   ## Example
       setup_with_mocks([
-        {HashDict, [], [get: fn(%{}, "http://example.com") -> "<html></html>" end]}
+        {Map, [], [get: fn(%{}, "http://example.com") -> "<html></html>" end]}
       ]) do
         foo = "bar"
         {:ok, foo: foo}
       end
 
       test "setup_all_with_mocks base case" do
-        assert HashDict.get(%{}, "http://example.com") == "<html></html>"
+        assert Map.get(%{}, "http://example.com") == "<html></html>"
       end
   """
   defmacro setup_with_mocks(mocks, do: setup_block) do
@@ -175,13 +175,13 @@ defmodule Mock do
 
   ## Example
       setup_with_mocks([
-        {HashDict, [], [get: fn(%{}, "http://example.com") -> "<html></html>" end]}
+        {Map, [], [get: fn(%{}, "http://example.com") -> "<html></html>" end]}
       ], context) do
         {:ok, test_string: Atom.to_string(context.test)}
       end
 
       test "setup_all_with_mocks with context", %{test_string: test_string} do
-        assert HashDict.get(%{}, "http://example.com") == "<html></html>"
+        assert Map.get(%{}, "http://example.com") == "<html></html>"
         assert test_string == "test setup_all_with_mocks with context"
       end
   """

--- a/test/mock_test.exs
+++ b/test/mock_test.exs
@@ -19,7 +19,7 @@ defmodule MockTest do
 
   test "multiple mocks" do
     with_mocks([
-      {HashDict,
+      {Map,
        [],
        [get: fn(%{}, "http://example.com") -> "<html></html>" end]},
       {String,
@@ -27,9 +27,19 @@ defmodule MockTest do
        [reverse: fn(x) -> 2*x end,
         length: fn(_x) -> :ok end]}
     ]) do
-      assert HashDict.get(%{}, "http://example.com") == "<html></html>"
+      assert Map.get(%{}, "http://example.com") == "<html></html>"
       assert String.reverse(3) == 6
       assert String.length(3) == :ok
+    end
+  end
+
+  test "mock fuctions with different arity" do
+    with_mock String,
+      [slice: fn(string, _range)      -> string end,
+       slice: fn(string, _range, _len) -> string end]
+    do
+      assert String.slice("test", 1..3) == "test"
+      assert String.slice("test", 1, 3) == "test"
     end
   end
 
@@ -70,13 +80,13 @@ defmodule MockTest do
     refute called String.reverse(4)
   end
 
-  test_with_mock "passthrough", HashDict, [:passthrough],
+  test_with_mock "passthrough", Map, [:passthrough],
     [] do
-    hd = HashDict.put(HashDict.new(), :a, 1)
-    assert HashDict.get(hd, :a) == 1
-    assert called HashDict.new()
-    assert called HashDict.get(hd, :a)
-    refute called HashDict.get(hd, :b)
+    hd = Map.put(Map.new(), :a, 1)
+    assert Map.get(hd, :a) == 1
+    assert called Map.new()
+    assert called Map.get(hd, :a)
+    refute called Map.get(hd, :b)
   end
 
   test "restore after exception" do


### PR DESCRIPTION
I added example how to use Mock to mock functions with same name and different arities and replaced HashDict -> Map to fix compile warnings, since HashDict is deprecating.