### PR TITLE
Bump package version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, add mock to your `mix.exs` dependencies:
 
 ```elixir
 def deps do
-  [{:mock, "~> 0.2.0", only: :test}]
+  [{:mock, "~> 0.3.0", only: :test}]
 end
 ```
 


### PR DESCRIPTION
0.2.x does not include methods described in Readme like: #setup_with_mocks