### PR TITLE
Implement assert_called as first class assertion, displays calls on failure

### DIFF
--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -134,6 +134,35 @@ defmodule Mock do
   end
 
   @doc """
+    Use inside a `with_mock` block to determine whether
+    a mocked function was called as expected. If the assertion fails, 
+    the calls that were received are displayed in the assertion message
+
+    ## Example
+
+        assert_called HTTPotion.get("http://example.com")
+    """
+  defmacro assert_called({{:., _, [module, f]}, _, args}) do
+    quote do
+      unquoted_module = unquote(module)
+      value = :meck.called(unquoted_module, unquote(f), unquote(args))
+
+      unless value do
+        calls = unquoted_module 
+                |> :meck.history()
+                |> Enum.with_index()
+                |> Enum.map(fn {{_, {m, f, a}, ret}, i} ->
+                  "#{i}. #{m}.#{f}(#{a |> Enum.map(&Kernel.inspect/1) |> Enum.join(",")}) (returned #{inspect ret})"
+                end)
+                |> Enum.join("\n")
+
+        raise ExUnit.AssertionError,
+          message: "Expected call but did not receive it. Calls which were received:\n\n#{calls}"
+      end
+    end
+  end
+
+  @doc """
   Mocks up multiple modules prior to the execution of each test in a case and
   execute the callback specified.
 

--- a/test/mock_test.exs
+++ b/test/mock_test.exs
@@ -64,6 +64,26 @@ defmodule MockTest do
     end
   end
 
+  test "assert_called" do
+    with_mock String,
+      [reverse: fn(x) -> 2*x end,
+      length: fn(_x) -> :ok end] do
+      String.reverse(3)
+      assert_called(String.reverse(3))
+
+      try do
+            "This should never be tested" = assert_called(String.reverse(2))
+      rescue
+        error in [ExUnit.AssertionError] ->
+          """
+          Expected call but did not receive it. Calls which were received:
+          
+          0. Elixir.String.reverse(3) (returned 6)\
+          """ = error.message
+      end
+    end
+  end
+
   test_with_mock "test_with_mock",
     String,
     [reverse: fn(_x) -> :ok end] do


### PR DESCRIPTION
Fixes #78.

Defines an assertion which displays calls actually made when it fails. Example:

```
defmodule Example do
  use ExUnit.Case

  import Mock

  test "example" do
    with_mock String,
      [reverse: fn(x) -> 2*x end,
       length: fn(_x) -> :ok end] do
      String.reverse(3)

      # Passes...
      assert_called(String.reverse(3))

      # Fails with ExUnit error:
      #
      # Expected call but did not receive it. Calls which were received:
      #
      # 0. Elixir.String.reverse(3) (returned 6)
      #
      assert_called(String.reverse(2))
    end
  end
end
```
