### PR TITLE
point documentation link to hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We use the Erlang [meck library](https://github.com/eproxus/meck) to provide
 module mocking functionality for Elixir. It uses macros in Elixir to expose the
 functionality in a convenient manner for integrating in Elixir tests.
 
-See the full [reference documentation](http://jjh42.github.io/mock).
+See the full [reference documentation](https://hexdocs.pm/mock/Mock.html).
 
 ## Installation
 First, add mock to your `mix.exs` dependencies:


### PR DESCRIPTION
The documentation link in the README seems to be broken, so I pointed it to the hex docs instead.