### PR TITLE
Upgrade meck from 0.8.8 to 0.8.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: elixir
 elixir:
   - 1.5.1
+  - 1.8
 env:
   - MIX_ENV=test
 otp_release:

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Mock.Mixfile do
 
   defp deps do
     [
-      {:meck, "~> 0.8.8"},
+      {:meck, "~> 0.8.13"},
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
       {:markdown, github: "devinus/markdown", only: :dev},
       {:excoveralls, "~> 0.7.2", only: :test}

--- a/mix.lock
+++ b/mix.lock
@@ -12,7 +12,7 @@
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "markdown": {:git, "https://github.com/devinus/markdown.git", "d065dbcc4e242a85ca2516fdadd0082712871fd8", []},
-  "meck": {:hex, :meck, "0.8.8", "eeb3efe811d4346e1a7f65b2738abc2ad73cbe1a2c91b5dd909bac2ea0414fa6", [:rebar3], [], "hexpm"},
+  "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},


### PR DESCRIPTION
Upgrades meck from 0.8.8 to 0.8.13.

Adds support for OTP 21 and elixir 1.8.

Adds Elixir 1.8 to CI.

Closes https://github.com/jjh42/mock/issues/96.