### PR TITLE
:meck.unload on exit

### DIFF
--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -198,8 +198,9 @@ defmodule Mock do
       setup do
         mock_modules(unquote(mocks))
 
-        # The mocks are linked to the process that setup all the tests and are
-        # automatically unloaded when that process shuts down
+        on_exit(fn ->
+          :meck.unload()
+        end)
 
         unquote(setup_block)
       end
@@ -228,6 +229,11 @@ defmodule Mock do
     quote do
       setup unquote(context) do
         mock_modules(unquote(mocks))
+
+        on_exit(fn ->
+          :meck.unload()
+        end)
+
         unquote(setup_block)
       end
     end


### PR DESCRIPTION
When running tests using `setup_with_mock` the mocks aren't actually unloaded fast enough (or maybe not at all) and sometimes they pass through to other tests (which don't want the mocks to be active at all). All the tests I did were on `async: false` and this still happened. Then I noticed you don't unload explicitly the mocks so hence the PR. I unload the mocks globally using `:meck.unload()` but I figure you don't want to use the mocks in different tests (setting them in one test and unloading in different) as the loading/unloading is indeterministic. I'm convinced it's pretty safe to unload all the mocks at the end of the test every time the test is finished. This happens in ExUnit's `on_exit`.