### PR TITLE
Fix README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ defmodule MyTest do
   test_with_mock "test_name", HTTPotion,
     [get: fn(_url) -> "<html></html>" end] do
     HTTPotion.get("http://example.com")
-    assert_called HTTPotion.get("http://example.com")
+    assert called HTTPotion.get("http://example.com")
   end
 end
 ````
@@ -165,7 +165,7 @@ defmodule MyTest do
     [get: fn(_url, _headers) -> doc end] do
 
     HTTPotion.get("http://example.com", [foo: :bar])
-    assert_called HTTPotion.get("http://example.com", :_)
+    assert called HTTPotion.get("http://example.com", :_)
   end
 end
 ````
@@ -183,7 +183,7 @@ defmodule MyTest do
 
   test_with_mock "test_name", IO, [:passthrough], [] do
     IO.puts "hello"
-    assert_called IO.puts "hello"
+    assert called IO.puts "hello"
   end
 end
 ````
@@ -304,7 +304,7 @@ defmodule MyTest do
   test "test_name" do
     with_mock HTTPotion, [get: fn(_url) -> "<html></html>" end] do
       HTTPotion.get("http://example.com")
-      assert_called HTTPotion.get("http://example.com")
+      assert called HTTPotion.get("http://example.com")
     end
   end
 end
@@ -324,7 +324,7 @@ defmodule MyTest do
   test "test_name" do
     with_mock HTTPotion, [get: fn(_url) -> "<html></html>" end] do
       HTTPotion.get("http://example.com")
-      assert_called HTTPotion.get(:_)
+      assert called HTTPotion.get(:_)
     end
   end
 end


### PR DESCRIPTION
The function `assert_called()` does not exists, the correct approach is to use `assert called()`.

I tried a lot use `assert_called()` but it raises an error, so I accidentally change to `assert called()` and worked fine.