### PR TITLE
Fix docstring markup for with_mocks

### DIFF
--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -50,10 +50,10 @@ defmodule Mock do
   Mock up multiple modules for the duration of `test`.
 
   ## Example
-  with_mocks([{HTTPotion, opts, [{get: fn("http://example.com") -> "<html></html>" end}]}]) do
-    # Tests that make the expected call
-    assert called HTTPotion.get("http://example.com")
-  end
+      with_mocks([{HTTPotion, opts, [{get: fn("http://example.com") -> "<html></html>" end}]}]) do
+        # Tests that make the expected call
+        assert called HTTPotion.get("http://example.com")
+      end
   """
   defmacro with_mocks(mocks, do: test) do
     quote do


### PR DESCRIPTION
Indent the example, so that it gets marked up as a code block.