### PR TITLE
[Issue 80] Update README with working input-dependent returns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,14 @@ defmodule MyTest do
   import Mock
 
   test "mock functions with multiple returns" do
-    with_mocks(HTTPotion, [
+    with_mock(Map, [
       get: fn
-        "http://example.com" -> "<html>Hello from example.com</html>"
-        "http://example.org" -> "<html>example.org says hi</html>"
+        (%{}, "http://example.com") -> "<html>Hello from example.com</html>"
+        (%{}, "http://example.org") -> "<html>example.org says hi</html>"
       end
     ]) do
-      assert HTTPotion.get("http://example.com") == "<html>Hello from example.com</html>"
-      assert HTTPotion.get("http://example.org") == "<html>example.org says hi</html>"
+      assert Map.get(%{}, "http://example.com") == "<html>Hello from example.com</html>"
+      assert Map.get(%{}, "http://example.org") == "<html>example.org says hi</html>"
     end
   end
 end

--- a/test/mock_test.exs
+++ b/test/mock_test.exs
@@ -17,6 +17,18 @@ defmodule MockTest do
     end
   end
 
+  test "mock functions with multiple returns" do
+    with_mock(Map, [
+      get: fn
+        (%{}, "http://example.com") -> "<html>Hello from example.com</html>"
+        (%{}, "http://example.org") -> "<html>example.org says hi</html>"
+      end
+    ]) do
+      assert Map.get(%{}, "http://example.com") == "<html>Hello from example.com</html>"
+      assert Map.get(%{}, "http://example.org") == "<html>example.org says hi</html>"
+    end
+  end
+
   test "multiple mocks" do
     with_mocks([
       {Map,


### PR DESCRIPTION
Documentation and test update for [Issue 80](https://github.com/jjh42/mock/issues/80).

This PR updates the `README` example for input-dependent returns. The original example was calling `with_mocks`, when it needed to call `with_mock` (singular). The new example uses `Map` so that it doesn't rely on `HTTPotion`. I also added this example to the test files, to verify that it compiles and passes.