### PR TITLE
add a thin wrapper around :meck.passthrough

### DIFF
--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -120,6 +120,24 @@ defmodule Mock do
   end
 
   @doc """
+  Call original function inside mock anonymous function.
+  Allows overriding only a certain behavior of a function.
+  Compatible with passthrough option.
+
+  ## Example
+
+      with_mock String, [:passthrough], [reverse: fn(str) ->
+           passthrough([str]) <> "!" end] do
+         assert String.reverse("xyz") == "zyx!"
+      end
+  """
+  defmacro passthrough(args) do
+    quote do
+      :meck.passthrough(unquote(args))
+    end
+  end
+
+  @doc """
     Use inside a `with_mock` block to determine whether
     a mocked function was called as expected.
 

--- a/test/mock_test.exs
+++ b/test/mock_test.exs
@@ -112,13 +112,19 @@ defmodule MockTest do
     refute called String.reverse(4)
   end
 
-  test_with_mock "passthrough", Map, [:passthrough],
+  test_with_mock "passthrough option", Map, [:passthrough],
     [] do
     hd = Map.put(Map.new(), :a, 1)
     assert Map.get(hd, :a) == 1
     assert called Map.new()
     assert called Map.get(hd, :a)
     refute called Map.get(hd, :b)
+  end
+
+  test_with_mock "passthrough in anon mock function", String, [:passthrough],
+    [reverse: fn x -> passthrough([x]) <> "!" end] do
+    assert String.reverse("xyz") == "zyx!"
+    assert called String.reverse("xyz")
   end
 
   test "restore after exception" do


### PR DESCRIPTION
As this is a thin wrapper, it doesn't perform any checks and has the same syntax of wrapping args in `[]`.

Better macro that is available only inside anonymous mock functions and has nicer syntax for args could theoretically be possible, but would require much more work and will be much harder to maintain.

If you are interestered in that kind of macro, let me know - I can try and spend some time implementing it.