### PR TITLE
add assert_called_exactly

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ See the full [reference documentation](https://hexdocs.pm/mock/Mock.html).
 		* [Assert called - pattern matching](#Assert-called---pattern-matching)
 		* [Assert call order](#Assert-call-order)
 	* [Assert not called - assert a specific function was not called](#Assert-not-called---assert-a-specific-function-was-not-called)
+	* [Assert called exactly - assert a specific function was called exactly x times](#Assert-called-exactly---assert-a-specific-function-was-called-exactly-x-times)
 	* [NOT SUPPORTED - Mocking internal function calls](#NOT-SUPPORTED---Mocking-internal-function-calls)
 	* [Tips](#Tips)
 	* [Help](#Help)
@@ -347,6 +348,31 @@ defmodule MyTest do
 
       # Using Specific Value
       assert_not_called HTTPotion.get("http://another-example.com")
+    end
+  end
+end
+```
+
+## Assert called exactly - assert a specific function was called exactly x times
+
+`assert_called_exactly` will assert that a mocked function was called exactly the expected number of times.
+
+```elixir
+defmodule MyTest do
+  use ExUnit.Case, async: false
+
+  import Mock
+
+  test "test_name" do
+    with_mock HTTPotion, [get: fn(_url) -> "<html></html>" end] do
+      HTTPotion.get("http://example.com")
+      HTTPotion.get("http://example.com")
+
+      # Using Wildcard
+      assert_called_exactly HTTPotion.get(:_), 2
+
+      # Using Specific Value
+      assert_called_exactly HTTPotion.get("http://example.com"), 2
     end
   end
 end

--- a/test/mock_test.exs
+++ b/test/mock_test.exs
@@ -96,6 +96,24 @@ defmodule MockTest do
     end
   end
 
+  test "assert_called_exactly" do
+    with_mock String, [reverse: fn(x) -> 2*x end] do
+      String.reverse(2)
+      String.reverse(2)
+      String.reverse(2)
+      assert_called_exactly(String.reverse(2), 3)
+
+      try do
+        assert_called_exactly(String.reverse(2), 2)
+      rescue
+        error in [ExUnit.AssertionError] ->
+          """
+          Expected Elixir.String.reverse(2) to be called exactly 2 time(s), but it was called (number of calls: 3)\
+          """ = error.message
+      end
+    end
+  end
+
   test "assert_not_called" do
     with_mock String,
       [reverse: fn(x) -> 2*x end] do

--- a/test/mock_test.exs
+++ b/test/mock_test.exs
@@ -77,14 +77,12 @@ defmodule MockTest do
   end
 
   test "assert_called" do
-    with_mock String,
-      [reverse: fn(x) -> 2*x end,
-      length: fn(_x) -> :ok end] do
+    with_mock String, [reverse: fn(x) -> 2*x end] do
       String.reverse(3)
       assert_called(String.reverse(3))
 
       try do
-            "This should never be tested" = assert_called(String.reverse(2))
+        "This should never be tested" = assert_called(String.reverse(2))
       rescue
         error in [ExUnit.AssertionError] ->
           """


### PR DESCRIPTION
I've added the `assert_called_exactly` assertation which is related to what was proposed here https://github.com/jjh42/mock/issues/116 inspired by RSpec Mocks.