### PR TITLE
Fix typo for `call_history` doc in the Mock module.

### DIFF
--- a/lib/mock.ex
+++ b/lib/mock.ex
@@ -250,7 +250,7 @@ defmodule Mock do
   end
 
   @doc """
-  Helper function to get the hsitory of mock functions executed.
+  Helper function to get the history of mock functions executed.
 
   ## Example
 


### PR DESCRIPTION
Fix typo for `call_history` doc in the Mock module.